### PR TITLE
setting change for heroku asset pipeline

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'


### PR DESCRIPTION
Herokuでアセットパイプラインが読み込まれない問題を解決するための修正を行いました

追記：これでHerokuは無事動きました