### PR TITLE
return to _path about password reset

### DIFF
--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -5,8 +5,8 @@
   
   <div class="row signup-forms">
     <div class="col-md-6 col-md-offset-3">
-      <%#= form_with(model: @user, url: password_resets_path(params[:id]), method: :patch, local: true) do |f| %>
-      <%= form_with(model: @user, url: "/password_resets/#{@user.id}", method: :patch, local: true) do |f| %>
+      <%= form_with(model: @user, url: password_resets_path(params[:id]), method: :patch, local: true) do |f| %>
+      <%#= form_with(model: @user, url: "/password_resets/#{@user.id}", method: :patch, local: true) do |f| %>
 
         <%= render 'shared/error_messages',object: f.object %>
         <%= hidden_field_tag :email, @user.email %>


### PR DESCRIPTION
パスワードリセットのビューで、form_withの送信先を名前付きルートで指定する方法に変更しました