### PR TITLE
modify movement after user-create and make header-icon a link to root…

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -336,6 +336,10 @@ header{
   
 }
 
+.activate-wrapper{
+  padding-top: 60px;
+}
+
 .user-wrapper{
   padding-top: 65px;
   padding-left: 20px;

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,5 +1,10 @@
 class AccountActivationsController < ApplicationController
 
+  def index
+    @user = User.find_by(id: current_user.id)
+  end
+  
+
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
       #redirect_to new_detail_path
       # TODO: ここでユーザー認証を促す画面にリダイレクトさせるようにあとで設定する
       # redirect_to root_url
-      redirect_to root_path
+      redirect_to account_activations_path
     else
       render 'new'
     end

--- a/app/views/account_activations/index.html.erb
+++ b/app/views/account_activations/index.html.erb
@@ -1,0 +1,3 @@
+<div class="activate-wrapper">
+  <h1>Please activate your account via link in the email sent to your address.</h1>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <%= image_tag "logos/logo_transparent.png", class: "main-logo" %>
+  <%= link_to image_tag("logos/logo_transparent.png", class: "main-logo"), root_path %> 
   <% if logged_in? %>
     <li class="dropdown" >
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
     end
   end
   resources :sessions, only: [:index, :create, :destroy]
-  resources :account_activations, only: [:edit]
+  resources :account_activations, only: [:index, :edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
   resources :homes,               only: [:index]


### PR DESCRIPTION
ユーザー登録後のリダイレクト先を、メール認証を促すページに変更しました。
また、ヘッダーのアプリロゴアイコンを、root_pathへのリンクに改造しました。